### PR TITLE
Use laravel Cache driver in place of file and redis code

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,16 +123,11 @@ var_dump($obj);
 
 #### Search
 
-This function is a sql query builder wrapped around the query function.
+This function is a sql query builder wrapped around the query function. Accepts instance of laravels QueryBuilder.
 ```php
-$search = [];
-$search[] = [
-    'firstname' => ['=', 'John'],
-    'lastname' => ['=', 'Smith'],
-    'login_date' => ['>=', '00-00-00 00:00:00'],
-];
+$query = DB::table('Leads')->select('id', 'firstname', 'lastname')->where('firstname', 'John');
 
-$obj = Vtiger::search('Leads', $search);
+$obj = Vtiger::search('Leads', $query);
 
 //loop over result
 foreach($obj->result as $result) {
@@ -140,6 +135,12 @@ foreach($obj->result as $result) {
 }
 ```
 
+By default the function will quote but not escape your inputs, if you wish for your data to not be quoted, set the 3rd paramater to false like so:
+```php
+$obj = Vtiger::search('Leads', $query, false);
+```
+
+Also keep in mind that Victiger has several limitations on it's sql query capabilities. You can not use conditional grouping i.e "where (firstname = 'John' AND 'lastname = 'Doe') OR (firstname = 'Jane' AND lastname = 'Smith') will fail.
 #### Query
 
 To use the [Query Operation](http://community.vtiger.com/help/vtigercrm/developers/third-party-app-integration.html#query-operation), you first need to create a SQL query.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ Use the Vtiger webservice (REST) API from within Laravel for the following opera
 - Retrieve
 - Update
 - Delete
+- Search
 - Query
 - Describe
 
-See [Third Party App Integration (REST APIs)](http://community.vtiger.com/help/vtigercrm/developers/third-party-app-integration.html) 
+See [Third Party App Integration (REST APIs)](http://community.vtiger.com/help/vtigercrm/developers/third-party-app-integration.html)
 
 ## Installation, Configuration and Usage
 
@@ -46,7 +47,6 @@ See [Third Party App Integration (REST APIs)](http://community.vtiger.com/help/v
 - In your application, edit *config/vtiger.php* and replace the following array values
   - Set the url to the https://{DOMAIN_NAME}/webservice.php
   - Set the username and accesskey with your CRM username and access key.
-  - Set the session drive to either file or reddis
   - Set persistconnection to false if you want a fresh login with each request
 
     |key              |value                                |
@@ -54,7 +54,6 @@ See [Third Party App Integration (REST APIs)](http://community.vtiger.com/help/v
     |url              |http://www.example.com/webservice.php|
     |username         |API                                  |
     |accesskey        |irGsy9HB0YOZdEA                      |
-    |sessiondriver    |file                                 |
     |persistconnection|true                                 |
     |max_retries      |10                                   |
 
@@ -70,7 +69,7 @@ use Vtiger;
 
 #### Create
 
-To insert a record into the CRM, first create an array of data to insert. Don't forget the added the id of the `assigned_user_id` (i.e. '4x12') otherwise the insert will fail as `assigned_user_id` is a mandatory field. 
+To insert a record into the CRM, first create an array of data to insert. Don't forget the added the id of the `assigned_user_id` (i.e. '4x12') otherwise the insert will fail as `assigned_user_id` is a mandatory field.
 ```php
 $data = array(
     'assigned_user_id' => '',
@@ -120,6 +119,25 @@ $obj = Vtiger::retrieve($id);
 
 // do someting with the result
 var_dump($obj);
+```
+
+#### Search
+
+This function is a sql query builder wrapped around the query function.
+```php
+$search = [];
+$search[] = [
+    'firstname' => ['=', 'John'],
+    'lastname' => ['=', 'Smith'],
+    'login_date' => ['>=', '00-00-00 00:00:00'],
+];
+
+$obj = Vtiger::search('Leads', $search);
+
+//loop over result
+foreach($obj->result as $result) {
+    // do something
+}
 ```
 
 #### Query

--- a/src/Config/config.php
+++ b/src/Config/config.php
@@ -5,7 +5,6 @@ return [
     'url' => 'path/to/vtiger/webservice.php',
     'username' => '',
     'accesskey' => '',
-    'sessiondriver' => 'file', //reddis or file
     'persistconnection' => true,
     'max_retries' => 10
 ];

--- a/src/Vtiger.php
+++ b/src/Vtiger.php
@@ -320,23 +320,19 @@ class Vtiger
         return $this->_processResult($response);
     }
 
-    public function search($module, $array)
+    public function search($query, $quote = true)
     {
-        if (empty($array) || !$module) {
-            throw VtigerError::init($this->vTigerErrors, 4);
-        }
-
-        $query = DB::table($module);
-        foreach ($array as $item) {
-            $query->where(key($item), $item[key($item)][0], $item[key($item)][1]);
-        }
-
         $bindings = $query->getBindings();
         $queryString = $query->toSQL();
 
         foreach ($bindings as $binding) {
-            $queryString = preg_replace('/\?/', DB::connection()->getPdo()->quote($binding), $queryString, 1);
+            if ($quote) {
+                $queryString = preg_replace('/\?/', DB::connection()->getPdo()->quote($binding), $queryString, 1);
+            } else {
+                $queryString = preg_replace('/\?/', $binding, $queryString, 1);
+            }
         }
+        $queryString = str_replace('`', '', $queryString) . ';';
 
         return $this->query($queryString);
     }
@@ -582,7 +578,7 @@ class Vtiger
         if (!isset($processedData->error)) {
             throw VtigerError::init($this->vTigerErrors, 3);
         }
-
+        dd($processedData);
         throw VtigerError::init($this->vTigerErrors, 0, $processedData->error->message);
     }
 }

--- a/src/Vtiger.php
+++ b/src/Vtiger.php
@@ -578,7 +578,6 @@ class Vtiger
         if (!isset($processedData->error)) {
             throw VtigerError::init($this->vTigerErrors, 3);
         }
-        dd($processedData);
         throw VtigerError::init($this->vTigerErrors, 0, $processedData->error->message);
     }
 }

--- a/src/Vtiger.php
+++ b/src/Vtiger.php
@@ -5,7 +5,6 @@ namespace Clystnet\Vtiger;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Client;
 use InvalidArgumentException;
-use Mockery\CountValidator\Exception;
 use Psr\Http\Message\ResponseInterface;
 use Config;
 use Cache;
@@ -18,7 +17,6 @@ use Cache;
  */
 class Vtiger
 {
-
     /** @var VtigerErrorElement[] */
     private $vTigerErrors;
 
@@ -104,16 +102,10 @@ class Vtiger
         // Get the sessionData from the cache
         $sessionData = json_decode(Cache::get('clystnet_vtiger'));
 
-        if (!$sessionData) {
-            throw VtigerError::init($this->vTigerErrors, 8, 'Could not get the session data from index clystnet_vtiger');
-        }
-
         if (isset($sessionData)) {
-            if (
-                isset($sessionData) &&
+            if (isset($sessionData) &&
                 property_exists($sessionData, 'expireTime') &&
-                property_exists($sessionData, 'token')
-            ) {
+                property_exists($sessionData, 'token')) {
                 if ($sessionData->expireTime < time() || empty($sessionData->token)) {
                     $sessionData = $this->storeSession();
                 }
@@ -172,13 +164,13 @@ class Vtiger
         } while (!isset($loginResult->success) && $tryCounter <= $this->maxRetries);
 
         if ($tryCounter >= $this->maxRetries) {
-            throw new VtigerError("Could not complete login request within " . $this->maxRetries . " tries", 5);
+            throw new VtigerError('Could not complete login request within ' . $this->maxRetries . ' tries', 5);
         }
 
         // If api login failed
         if ($response->getStatusCode() !== 200 || !$loginResult->success) {
             if (!$loginResult->success) {
-                if ($loginResult->error->code == "INVALID_USER_CREDENTIALS" || $loginResult->error->code == "INVALID_SESSIONID") {
+                if ($loginResult->error->code == 'INVALID_USER_CREDENTIALS' || $loginResult->error->code == 'INVALID_SESSIONID') {
                     if (!Cache::has('clystnet_vtiger')) {
                         throw VtigerError::init($this->vTigerErrors, 8, 'Nothing to delete for index clystnet_vtiger');
                     } else {
@@ -193,7 +185,6 @@ class Vtiger
         } else {
             // login ok so get sessionid and update our session
             $sessionId = $loginResult->result->sessionName;
-
 
             if (Cache::has('clystnet_vtiger')) {
                 $json = json_decode(Cache::pull('clystnet_vtiger'));
@@ -219,9 +210,6 @@ class Vtiger
 
         $output = (object)$updated;
         $cacheResult = Cache::forever('clystnet_vtiger', json_encode($output));
-        if (!$cacheResult) {
-            throw VtigerError::init($this->vTigerErrors, 8, 'Could not set the session data in index clystnet_vtiger');
-        }
 
         return $output;
     }
@@ -252,17 +240,17 @@ class Vtiger
         } while (!isset($this->_processResponse($response)->success) && $tryCounter <= $this->maxRetries);
 
         if ($tryCounter >= $this->maxRetries) {
-            throw new VtigerError("Could not complete get token request within " . $this->maxRetries . " tries", 6);
+            throw new VtigerError('Could not complete get token request within ' . $this->maxRetries . ' tries', 6);
         }
 
         // decode the response
         $challenge = $this->_processResult($response);
 
         // Everything ok so create a token from response
-        $output = array(
+        $output = [
             'token' => $challenge->result->token,
             'expireTime' => $challenge->result->expireTime,
-        );
+        ];
 
         return $output;
     }
@@ -287,11 +275,11 @@ class Vtiger
                 'POST',
                 $this->url,
                 [
-                'query' => [
-                    'operation' => 'logout',
-                    'sessionName' => $sessionId
+                    'query' => [
+                        'operation' => 'logout',
+                        'sessionName' => $sessionId
+                    ]
                 ]
-            ]
             );
         } catch (GuzzleException $e) {
             throw VtigerError::init($this->vTigerErrors, 7, $e->getMessage());
@@ -484,12 +472,12 @@ class Vtiger
                 'GET',
                 $this->url,
                 [
-                'query' => [
-                    'operation' => 'describe',
-                    'sessionName' => $sessionId,
-                    'elementType' => $elementType
+                    'query' => [
+                        'operation' => 'describe',
+                        'sessionName' => $sessionId,
+                        'elementType' => $elementType
+                    ]
                 ]
-            ]
             );
         } catch (GuzzleException $e) {
             throw VtigerError::init($this->vTigerErrors, 7, $e->getMessage());

--- a/src/Vtiger.php
+++ b/src/Vtiger.php
@@ -59,7 +59,7 @@ class Vtiger
             2 => new VtigerErrorElement('Success property not set on VTiger response', 2),
             3 => new VtigerErrorElement('Error property not set on VTiger response when success is false', 3),
             4 => new VtigerErrorElement('There are no search fields in the array', 4),
-            5 => new VtigerErrorElement('Could not complete login request within ' . $this->maxRetries . ' tries', 5),
+                5 => new VtigerErrorElement('Could not complete login request within ' . $this->maxRetries . ' tries', 5),
             6 => new VtigerErrorElement(
                 'Could not complete get token request within ' . $this->maxRetries . ' tries',
                 6
@@ -191,7 +191,7 @@ class Vtiger
             if (Cache::has('clystnet_vtiger')) {
                 $json = json_decode(Cache::pull('clystnet_vtiger'));
                 $json->sessionid = $sessionId;
-                Cache::forever('clystnetVtiger', json_encode($json));
+                Cache::forever('clystnet_vtiger', json_encode($json));
             } else {
                 throw VtigerError::init($this->vTigerErrors, 8, 'There is no key for index clystnet_vtiger.');
             }


### PR DESCRIPTION
Laravel has a built in Cache class that will allows us to store and fetch information without having to directly access the Storage/Redis/Memcache/Database classes defaulting to which ever driver the user has set in their .env file.

This cleans up the code a bit, removes a unnecessary custom implementation. Also contains some PSR2 fixes from php-cs-fixer(sorry about that).